### PR TITLE
Implemented defaultPageSize to @Paginator decorator and spec test for it

### DIFF
--- a/lib/paginators.ts
+++ b/lib/paginators.ts
@@ -11,7 +11,8 @@ export interface PaginateParams {
 };
 
 export interface PaginateConfig {
-  maxPageSize?: number
+  maxPageSize?: number,
+  defaultPageSize?: number,
   paginator?: new(params: PaginateParams) => Paginator,
 };
 
@@ -20,7 +21,7 @@ export const Paginate = createParamDecorator<PaginateConfig>((config: PaginateCo
   const baseUrl = `${req.protocol}://${req.get('host')}${req.baseUrl}${req.path}`;
   const paginator = config.paginator || PagedPaginator;
 
-  let pageSize = parseInt(req.query.pageSize) || 10;
+  let pageSize = parseInt(req.query.pageSize) || config.defaultPageSize || 10;
   if (config.maxPageSize) {
     pageSize = Math.min(pageSize, config.maxPageSize)
   }

--- a/lib/spec/pagination.spec.ts
+++ b/lib/spec/pagination.spec.ts
@@ -46,6 +46,18 @@ describe('@Paginate', () => {
 
 		expect(result.pageSize).to.eq(10);
 	})
+
+	it('defaults page size to defaultPageSize if not provided', () => {
+		const executionContext = executionContextWithQueryParams({});
+
+		const factory = getPaginationFactory({
+			defaultPageSize: 20
+		});
+		const result = factory(executionContext);
+
+		expect(result.pageSize).to.eq(20);
+	})
+
 })
 
 function executionContextWithQueryParams(query: any) {


### PR DESCRIPTION
## Description

Added `defaultPageSize` as an attribute to `PaginateConfig`. If none is passed, defaults to 10 like it was before;

Fixes #4 (issue)

## Type of change

- [    ] Bug fix
- [ x ] New feature
- [    ] Breaking change
- [    ] This change requires a documentation update

## How Has This Been Tested?

Added a test scenario on pagination spec.

- [ x ] If pageSize is not provided on query param, defaults pageSize to defaultPageSize